### PR TITLE
fixed a case when an empty css file has found in the source folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ function gulpCSSPurge() {
 
     var purgedCSS = ""
     try {
-      purgedCSS = new Buffer(purge(null, null, null, file.contents.toString()));
+      var content = file.contents.toString();
+      if(!content) return cb();
+      purgedCSS = new Buffer(purge(null, null, null, content));
     } catch (err) {
       return cb(new PluginError(PLUGIN_NAME, err));
     }


### PR DESCRIPTION
i had this issue when tried to use the package, one of my css files in the source folder was empty (LESS generated it like that due to empty rules inside)